### PR TITLE
Add highlighting for macro expansion

### DIFF
--- a/gnuplot-mode.el
+++ b/gnuplot-mode.el
@@ -237,6 +237,7 @@ multiple lines.  Used in `gnuplot-find-indent-column' and in
     (,gp-variables          . font-lock-variable-name-face)
     ("!"                    . font-lock-negation-char-face)
     ("\\(\\<[a-z]+[a-z_0-9(),]*\\)[ \t]*=" . font-lock-variable-name-face) ; variable declaration
+    ("@[a-z][a-z_0-9]*"     . font-lock-preprocessor-face) ; macro expansion
     ("\$[0-9]+"             . font-lock-string-face)   ; columns
     ("\\[\\([^]]+\\)\\]"    1 font-lock-string-face))) ; brackets
 


### PR DESCRIPTION
The regex for variable names is based on the one in the line right above it, for variable definitions (and therefore, like it, suffers from #11), but is somewhat simplified, since macro expansion doesn’t include argument lists and we can skip the word separator detection.

Fixes #10.